### PR TITLE
Refactored 'GetAllFolders()'

### DIFF
--- a/folders/folders.go
+++ b/folders/folders.go
@@ -8,38 +8,17 @@ func GetAllFolders(req *FetchFolderRequest) (*FetchFolderResponse, error) {
 	//Initialise Local Variables
 	var (
 		err error
-		f1  Folder
-		//Creates a Slice of pointers to Folders
-		fs []*Folder
 	)
 
-	//Creates a slice of folders
-	f := []Folder{}
+	//Call function, assigning result and errors returned
+	r, err := FetchAllFoldersByOrgID(req.OrgID)
 
-	//Call function, assigning result and discarding errors
-	r, _ := FetchAllFoldersByOrgID(req.OrgID)
-
-	//Iterate through the results slice
-	for k, v := range r {
-		//Append the Folder instances to 'f' slice
-		f = append(f, *v)
-	}
-
-	//Creates a slice of folders
-	var fp []*Folder
-
-	//Iterate through the copied results slice
-	for k1, v1 := range f {
-		//append 'v1' folder numerous times
-		fp = append(fp, &v1)
-	}
-
-	//Populate fetch folder response pointer initialised with 'Folder' field to fp results slice
-	var ffr *FetchFolderResponse
-	ffr = &FetchFolderResponse{Folders: fp}
+	//Populate fetch folder response pointer initialised with 'Folder' field to r results slice
+	var folder_fetch_response *FetchFolderResponse
+	folder_fetch_response = &FetchFolderResponse{Folders: r}
 
 	//Return fetch folder response pointer, and nil error
-	return ffr, nil
+	return folder_fetch_response, err
 }
 
 func FetchAllFoldersByOrgID(orgID uuid.UUID) ([]*Folder, error) {


### PR DESCRIPTION
Removed unnecessary copies being made of the response, and directly assign the folders response into the folder response struct.